### PR TITLE
Fix command syntax for installing gcc on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Additional dependencies required by models are listed [here](README.md#Models).
 
 Some algorithm implementations use `OpenMP` to support multi-threading. For Mac OS users, in order to run those algorithms efficiently, you might need to install `gcc` from Homebrew to have an OpenMP compiler:
 ```bash
-brew install gcc | brew link gcc
+brew install gcc && brew link gcc
 ```
 
 ## Getting started: your first Cornac experiment


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This pull request makes a minor update to the installation instructions in the `README.md` file, correcting the command for installing and linking `gcc` with Homebrew to use `&&` instead of `|` for proper sequential execution.
<!--- Why is this change required? What problem does it solve? -->

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
N.A.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
